### PR TITLE
fix: make headers visible

### DIFF
--- a/app/assets/stylesheets/core.css
+++ b/app/assets/stylesheets/core.css
@@ -1,6 +1,6 @@
 body { background-color: #f8f8f8; color: #333; margin:0; padding:0; font-family:"Lucida Grande", helvetica, arial, sans-serif; font-size: 13px; line-height: 18px; }
 
-h1,h2,h3,h4,h5,h6 {font-weight:normal; letter-spacing:-1px; margin:0; padding:0; margin-bottom:.7em; color:#FFF;}
+h1,h2,h3,h4,h5,h6 {font-weight:normal; letter-spacing:-1px; margin:0; padding:0; margin-bottom:.7em;}
 ul, ol {margin:0; padding:0; list-style-position:inside;}
 h2 {font-size:20px;}
 


### PR DESCRIPTION
The h element in the settings was set to a white color, making it
invisible on a white background. This commit removes the global
white color for headers which fixes the issue.
